### PR TITLE
Pass all tests excepting Test.Integration

### DIFF
--- a/NSoup/Helper/DataUtil.cs
+++ b/NSoup/Helper/DataUtil.cs
@@ -89,6 +89,12 @@ namespace NSoup.Helper
 						doc = null;
 					}
 				}
+                else
+                {
+                    charsetName = _defaultEncoding.HeaderName;
+                    docData = Encoding.GetEncoding(charsetName).GetString(data);
+                    doc = null;
+                }
 			}
 			else
 			{

--- a/NSoup/Helper/HttpConnection.cs
+++ b/NSoup/Helper/HttpConnection.cs
@@ -914,7 +914,6 @@ namespace NSoup.Helper
 		private bool ignoreHttpErrors = false;
 		private bool ignoreContentType = false;
 		private Parser parser;
-		private bool parserDefined = false; // called parser(...) vs initialized in ctor
 		private bool validateTSLCertificates = true;
 		private string postDataCharset = DataUtil.DefaultEncoding.ToString();
 

--- a/NSoup/Helper/StringUtil.cs
+++ b/NSoup/Helper/StringUtil.cs
@@ -98,7 +98,6 @@ namespace NSoup.Helper
 			var sb = new StringBuilder(s.Length);
 
 			var lastWasWhite = false;
-			var reachedNonWhite = false;
 
 			var l = s.Length;
 			for (var i = 0; i < l; i++)
@@ -114,7 +113,6 @@ namespace NSoup.Helper
 				{
 					sb.Append(c);
 					lastWasWhite = false;
-					reachedNonWhite = true;
 				}
 			}
 

--- a/NSoup/Nodes/Element.cs
+++ b/NSoup/Nodes/Element.cs
@@ -532,6 +532,8 @@ namespace NSoup.Nodes
         {
             get
             {
+                if (Parent == null) { return null; }
+
                 IList<Element> siblings = Parent.Children;
                 int index = siblings.IndexOf(this);
 

--- a/NSoup/Parse/CharacterReader.cs
+++ b/NSoup/Parse/CharacterReader.cs
@@ -26,7 +26,7 @@ namespace NSoup.Parse
                 throw new ArgumentNullException("input");
             }
 
-            input = Regex.Replace(input, "\r\n?", "\n"); // normalise carriage returns to newlines
+            //input = Regex.Replace(input, "\r\n?", "\n"); // normalise carriage returns to newlines
 
             this._input = input.ToCharArray();
             this._length = input.Length;

--- a/Test/Parser/HtmlParserTest.cs
+++ b/Test/Parser/HtmlParserTest.cs
@@ -939,7 +939,7 @@ namespace Test.Parser
             // (as defined in html5.) However in practise that lead to spurious matches against the author's intent.
             string html = "One &clubsuite; &clubsuit;";
             Document doc = NSoupClient.Parse(html);
-            Assert.AreEqual(StringUtil.NormaliseWhitespace("One &amp;clubsuite; ג™£"), doc.Body.Html());
+            Assert.AreEqual(StringUtil.NormaliseWhitespace("One &amp;clubsuite; \u2663"), doc.Body.Html());
         }
 
         [TestMethod]

--- a/Test/Safety/CleanerTest.cs
+++ b/Test/Safety/CleanerTest.cs
@@ -253,7 +253,7 @@ namespace Test.Safety
 
             Assert.AreEqual("<div><p>&bernou;</p></div>", customOut);
             Assert.AreEqual("<div>\n" +
-                " <p>ג„¬</p>\n" +
+                " <p>\u212C</p>\n" +
                 "</div>", defaultOut);
 
             os.SetEncoding(Encoding.ASCII);
@@ -278,7 +278,9 @@ namespace Test.Safety
         [TestMethod]
         public void cleansInternationalText()
         {
-            Assert.AreEqual("׀¿ׁ€׀¸׀²׀µׁ‚", NSoupClient.Clean("׀¿ׁ€׀¸׀²׀µׁ‚", Whitelist.None));
+            Assert.AreEqual("Кириллица", NSoupClient.Clean("Кириллица", Whitelist.None));
+            Assert.AreEqual("<b>اللغة العربية</b>", NSoupClient.Clean("<b>اللغة العربية</b>", Whitelist.Basic));
+            Assert.AreEqual("اللغةالعربية", NSoupClient.Clean("<b>اللغة</b><small>العربية</small>", Whitelist.None));
         }
     }
 }


### PR DESCRIPTION
Hello GeReV.

Although it is not perfect,
I fix codes to pass tests.
And current test cases seems to contain incorrect cases, so I update them.

All tests excepting Test.Integration become fine.

I did test on appveyor.
See [this PR's result](https://ci.appveyor.com/project/masa-suzu/nsoup/build/1.0.2) and [your latest main branch's result](https://ci.appveyor.com/project/masa-suzu/nsoup-dhmsm/build/1.0.1) in details.